### PR TITLE
Add ABAP SDK for IBM Watson

### DIFF
--- a/list.json
+++ b/list.json
@@ -121,6 +121,5 @@
   "hhelibeb/geohash-abap",
   "css-ch/abap-code-quality-analyzer",
   "mkysoft/xlsxreader",
-  "watson-developer-cloud/abap-sdk-nwas",
-  "watson-developer-cloud/abap-sdk-scp"
+  "watson-developer-cloud/abap-sdk-nwas"
 ]

--- a/list.json
+++ b/list.json
@@ -120,5 +120,7 @@
   "isisdanismanlik/NamespaceChanger",
   "hhelibeb/geohash-abap",
   "css-ch/abap-code-quality-analyzer",
-  "mkysoft/xlsxreader"
+  "mkysoft/xlsxreader",
+  "watson-developer-cloud/abap-sdk-nwas",
+  "watson-developer-cloud/abap-sdk-scp"
 ]


### PR DESCRIPTION
**Add ABAP SDK for IBM Watson:**
- SAP NetWeaver Application Server
- SAP Cloud Platform ABAP Environment