### PR TITLE
kgorin8/adt_transport_copy_plugin

### DIFF
--- a/related.json
+++ b/related.json
@@ -18,5 +18,6 @@
   "pvl/abap.tmbundle",
   "larshp/abaplint",
   "SAP/styleguides",
-  "ilyakaznacheev/abap-best-practice"
+  "ilyakaznacheev/abap-best-practice",
+  "kgorin8/adt_transport_copy_plugin"
 ]


### PR DESCRIPTION
ADT Transport of Copies plugin allows you to quickly create SAP transports from Eclipse