### PR TITLE
Add bothzoli/ABAP-IoC-Container to list.json

### DIFF
--- a/list.json
+++ b/list.json
@@ -180,5 +180,6 @@
   "OlegBash599/ZC8A_001",
   "abap-observability-tools/abap-metrics-provider",
   "victorizbitskiy/zconcurrency_api",
-  "appknight/dump_info"
+  "appknight/dump_info",
+  "bothzoli/ABAP-IoC-Container"
 ]


### PR DESCRIPTION
An ABAP inversion of control container (see also [this](https://dev.to/bothzoli/implementing-an-ioc-container-in-abap-534) article).