### PR TITLE
ABAP - JSON Encoder/Decoder by valdirmendesdev

### DIFF
--- a/list.json
+++ b/list.json
@@ -223,5 +223,6 @@
   "thedoginthewok/abapMermaid",
   "jrodriguez-rc/abap-ishmed-api-browser",
   "abapify/promise",
-  "OlegBash599/AnyTabUpdateTask"
+  "OlegBash599/AnyTabUpdateTask",
+  "valdirmendesdev/abap-json-encoder-decoder"
 ]


### PR DESCRIPTION
ABAP - JSON Encoder/Decoder - A tool to encode ABAP types to json and/or decode json to ABAP types.