### PR TITLE
Update list.json

### DIFF
--- a/list.json
+++ b/list.json
@@ -171,7 +171,7 @@
   "peyn/IDoc-with-ABAP-OOP",
   "pixelbaker/ABAP-RayTracer",
   "pokrakam/SAPlink-Git",
-  "provideplatform/proubc-chainlink-fall-hackathon-2022",
+  "provideplatform/prvd-chainlink-fall-hackathon-2022",
   "provideplatform/provide-abap",
   "raketenstart-abap/abap-feature-toggle",
   "raketenstart-abap/abap-tvarvc",


### PR DESCRIPTION
updates repo name from 'proubc-chainlink-fall-hackathon' to 'prvd-chainlink-fall-hackathon'