### PR TITLE
fix #196 update ZAP repo name

### DIFF
--- a/list.json
+++ b/list.json
@@ -72,7 +72,7 @@
   "ConjuringCoffee/abap-utesthelp",
   "coreline/ZDDIC_FINDER",
   "coreline/ZUML_DIAGRAM",
-  "Ctrl-Alt-Abel/ZAP",
+  "abeljohny/ZAP",
   "d023604/open-location-code-abap",
   "damir-majer/ABAPKoans",
   "DerGuteWolf/ABAP_TRANSLATION_HUB",


### PR DESCRIPTION
Hopefully fix failing update job probably due to changed repo name of ZAP project