### PR TITLE
Remove IBM/abap-sdk-btp-x

### DIFF
--- a/list.json
+++ b/list.json
@@ -115,7 +115,6 @@
   "hhelibeb/blowfish-abap",
   "hhelibeb/geohash-abap",
   "IBM/abap-sdk-nwas-x",
-  "IBM/abap-sdk-btp-x",
   "INVIXO/abapMQ",
   "irodrigob/alv_utilities",
   "isisdanismanlik/NamespaceChanger",


### PR DESCRIPTION
Since IBM has 2 repos with a lot of the same objects, that causes some duplicates.