### PR TITLE
equinor/sap-sapscript moved to equinor/sap-ca-sapscript

### DIFF
--- a/list.json
+++ b/list.json
@@ -337,6 +337,6 @@
   "furkancosgun/EITHER-FOR-ABAP",
   "furkancosgun/COROUTINES4ABAP",
   "furkancosgun/ABAP-CACHE-BOX",
-  "equinor/sap-sapscript",
+  "equinor/sap-ca-sapscript",
   "eplamsi/ork_core"
 ]


### PR DESCRIPTION
Looks like the repo was renamed.