### PR TITLE
Add ABAP-Utilities & abapToC (list) + abap-mcp (related)

### DIFF
--- a/list.json
+++ b/list.json
@@ -338,5 +338,7 @@
   "furkancosgun/COROUTINES4ABAP",
   "furkancosgun/ABAP-CACHE-BOX",
   "equinor/sap-ca-sapscript",
-  "eplamsi/ork_core"
+  "eplamsi/ork_core",
+  "palimkarakshay/ABAP-Utilities",
+  "palimkarakshay/abapToC"
 ]

--- a/related.json
+++ b/related.json
@@ -30,5 +30,6 @@
   "trr-official/abapunit2junit",
   "SAP/abap-cleaner",
   "RegestaItalia/trm-client",
-  "WeiKKJ/zcl_bi_data_auth"  
+  "WeiKKJ/zcl_bi_data_auth",
+  "palimkarakshay/abap-mcp"
 ]


### PR DESCRIPTION
Adding three open-source projects.

**list.json**
- `palimkarakshay/ABAP-Utilities` — plug-and-play generic ABAP/RAP utility classes (abapGit, MIT); ~6k lines of ABAP across 72 objects.
- `palimkarakshay/abapToC` — ZTOC transaction for one-click Transport-of-Copies create/release/import (abapGit, MIT).

**related.json**
- `palimkarakshay/abap-mcp` — offline MCP server for ABAP: abaplint static analysis, ABAP Cloud / Clean Core readiness, released-API lookup, and RAP scaffolding (Node/TS, MIT) — sits alongside abaplint and the VS Code tooling already listed.

All public, English, MIT-licensed, hosted on GitHub.